### PR TITLE
Adding the Events module

### DIFF
--- a/Events.ark
+++ b/Events.ark
@@ -1,0 +1,107 @@
+(import "List.ark")
+
+###
+# @meta Events
+# @brief Allows to register events listeners and emit events
+# =begin
+# (let em (events:manager:make))
+# (em.on "myType" (fun (value) (print "This is a callback")))
+# (em.emit "myType")  # => prints "This is a callback" thanks to the registered listener
+# =end
+# @author https://github.com/fabien-zoccola
+##
+(let events:manager:make (fun () {
+    # listeners list
+    (mut _listeners [])
+
+    ###
+    # @brief Checks if a given callback is valid (is a function or a closure)
+    # @param callback the callback to check
+    # @details Returns true if the callback is a function/closure, false otherwise
+    # =begin
+    # (closure._check_valid (fun (param) ()))  # => true
+    # (closure._check_valid (fun (param) {}))  # => true
+    # (closure._check_valid 5)  # => false
+    # =end
+    # @author https://github.com/fabien-zoccola
+    ##
+    (let _check_valid (fun (callback)
+        (or (= "Function" (type callback)) (= "Closure" (type callback)) )))
+
+    ###
+    # @brief Registers an event listener
+    # @param typ the type of the event to listen for
+    # @param callback the function/closure that will be called when an event is emitted
+    # @details Adds a [type callback] list to the listeners list
+    # =begin
+    # (closure.on "myType" (fun (param) ())
+    # =end
+    # @author https://github.com/fabien-zoccola
+    ##
+    (let on (fun (typ callback) 
+        (if (_check_valid callback)
+            (set _listeners (append _listeners [typ callback])))))
+
+    ###
+    # @brief Emits an event with a value
+    # @param val the emitted value
+    # @param typ the type of the emitted event
+    # @details Makes a forEach on the listeners list, and calls the callback. Returns a boolean of whether we called at least one listener
+    # =begin
+    # (closure.emitWith 5 "myType")
+    # =end
+    # @author https://github.com/fabien-zoccola
+    ##
+    (let emitWith (fun (val typ)
+        (list:forEach _listeners (fun (element) {
+            (mut found false)
+            (if (= typ (@ element 0)) {
+                ((@ element 1) val)
+                (set found true)
+            })
+            found
+        }))))
+
+    ###
+    # @brief Emits an event with no value
+    # @param typ the type of the emitted event
+    # @details Calls emitWith nil <typ>
+    # =begin
+    # (closure.emit "myType")
+    # =end
+    # @author https://github.com/fabien-zoccola
+    ##
+    (let emit (fun (typ)
+        (emitWith nil typ) ))
+
+    ###
+    # @brief Removes all listeners of a given type
+    # @param typ the type of event to remove from the list
+    # @details Returns if at least one listener has been removed
+    # =begin
+    # (closure.remove_listeners_of_type "myType")
+    # =end
+    # @author https://github.com/fabien-zoccola
+    ##
+    (let removeListenersOfType (fun (typ) {
+        (let newlist (list:filter _listeners (fun (element)
+            (!= typ (@ element 0)) )))
+        (let deleted (!= newlist _listeners))
+        (set _listeners newlist)
+        deleted
+    }))
+
+    (fun (
+        # listeners
+        &_listeners
+
+        # hidden methods
+        &_check_valid
+        
+        # methods
+        &on
+        &emit
+        &emitWith
+        &removeListenersOfType
+        ) ())
+}))

--- a/Events.ark
+++ b/Events.ark
@@ -52,15 +52,16 @@
     # =end
     # @author https://github.com/fabien-zoccola
     ##
-    (let emitWith (fun (val typ)
-        (list:forEach _listeners (fun (element) {
-            (mut found false)
+    (let emitWith (fun (val typ) {
+        (mut found false)
+        (list:forEach _listeners (fun (element)
             (if (= typ (@ element 0)) {
                 ((@ element 1) val)
                 (set found true)
-            })
-            found
-        }))))
+            })))
+        found
+    }))
+        
 
     ###
     # @brief Emits an event with no value

--- a/tests/all.ark
+++ b/tests/all.ark
@@ -11,6 +11,7 @@ Standard library
 # We *must* use functions for our tests because they create a new scope,
 # to avoid collisions with other tests, and avoid false positive tests.
 
+(import "events-tests.ark")
 (import "exceptions-tests.ark")
 (import "functional-tests.ark")
 (import "list-tests.ark")
@@ -21,6 +22,7 @@ Standard library
 (print "  ------------------------------")
 
 (print "  Total: " (+ 0 0
+    passed-events
     passed-exceptions
     passed-functional
     passed-list

--- a/tests/events-tests.ark
+++ b/tests/events-tests.ark
@@ -1,0 +1,41 @@
+(import "tests-tools.ark")
+
+(import "Events.ark")
+
+(let events-tests (fun () {
+    (mut tests 0)
+    (let start-time (time))
+
+    (let em (events:manager:make))
+
+    # _check_valid tests
+    (set tests (assert-eq true (em._check_valid (fun () ())) "check_valid" tests))
+    (set tests (assert-eq false (em._check_valid 4) "check_valid" tests))
+
+    # on tests
+    (em.on "myType" 4)
+    (set tests (assert-eq [] em._listeners "listeners empty" tests))
+    (em.on "myType" (fun (_) ()))
+    (set tests (assert-neq [] em._listeners "listeners with one element" tests))
+
+    # emit tests
+    (set tests (assert-eq false (em.emit "emitType") "emit" tests))
+    (em.on "emitType" (fun (_) ()))
+    (set tests (assert-eq true (em.emit "emitType") "emit" tests))
+
+    # emitWith tests
+    (set tests (assert-eq false (em.emitWith 1 "emitWithType") "emitWith" tests))
+    (em.on "emitWithType" (fun (_) ()))
+    (set tests (assert-eq true (em.emitWith 2 "emitWithType") "emitWith" tests))
+
+    # removeListenersOfType
+    (set tests (assert-eq false (em.removeListenersOfType "removeType") "removeListenersOfType" tests))
+    (em.on "removeType" (fun (_) ()))
+    (set tests (assert-eq true (em.removeListenersOfType "removeType") "removeListenersOfType" tests))
+
+    (recap "Events tests passed" tests (- (time) start-time))
+
+    tests
+}))
+
+(let passed-events (events-tests))


### PR DESCRIPTION
This module contains a closure `events:manager:make` that allows the creation of an event manager.
Available (and tested) functions:
* `(on <type> <callback>)`: register an event listener, whose callback will be called when an event of said type is emitted
* `(emitWith <value> <type>)`: emits an event and passing a value, and returns whether any listener was called
* `(emit <type>)`: alias of `(emitWith nil <type>)`
* `(removeListenersOfType <type>)`: removes the listeners of given type, and returns whether any were removed