### PR TITLE
Permit larger arguments to combinatorial functions

### DIFF
--- a/Math.ark
+++ b/Math.ark
@@ -769,7 +769,7 @@
 # @author https://github.com/SuperFola
 (let binomialCoeff (fun (_n _k)
   (if (<= _k _n)
-    (/ (factorial _n) (* (factorial _k) (factorial (- _n _k))))
+    (/ (permutations _n _k) (factorial _k))
     0)))
 
 # @brief Compute the number of ways to choose k items from n items without repetition and with order
@@ -779,7 +779,12 @@
 # @author https://github.com/SuperFola
 (let permutations (fun (_n _k)
   (if (<= _k _n)
-    (/ (factorial _n) (factorial (- _n _k)))
+    {
+      (mut _res 1)
+      (while (> _n k) {
+        (set _res (* _res _n))
+        (set _n (- _n 1)) })
+      _res }
     0)))
 
 # @brief Compare two real numbers and return true if the first one is near the second one (1e-7 precision)

--- a/Math.ark
+++ b/Math.ark
@@ -766,7 +766,7 @@
 # @details Evaluates to n! / (k! * (n - k)!) when k <= n and evaluates to zero when k > n.
 # @param _n total number of items
 # @param _k number of items that will be picked
-# @author https://github.com/SuperFola
+# @author https://github.com/SuperFola, https://github.com/kg583
 (let binomialCoeff (fun (_n _k)
   (if (<= _k _n)
     (/ (permutations _n _k) (factorial _k))
@@ -776,7 +776,7 @@
 # @details Evaluates to n! / (n - k)! when k <= n and evaluates to zero when k > n.
 # @param _n total number of items
 # @param _k number of items to pick
-# @author https://github.com/SuperFola
+# @author https://github.com/SuperFola, https://github.com/kg583
 (let permutations (fun ((mut _n) _k)
   (if (<= _k _n)
     {

--- a/Math.ark
+++ b/Math.ark
@@ -777,11 +777,12 @@
 # @param _n total number of items
 # @param _k number of items to pick
 # @author https://github.com/SuperFola
-(let permutations (fun (_n _k)
+(let permutations (fun ((mut _n) _k)
   (if (<= _k _n)
     {
       (mut _res 1)
-      (while (> _n k) {
+      (let _lower (- _n _k))
+      (while (> _n _lower) {
         (set _res (* _res _n))
         (set _n (- _n 1)) })
       _res }

--- a/tests/math-tests.ark
+++ b/tests/math-tests.ark
@@ -298,7 +298,8 @@
     (test:eq (math:binomialCoeff 4 1) 4)
     (test:eq (math:binomialCoeff 4 2) 6)
     (test:eq (math:binomialCoeff 4 3) 4)
-    (test:eq (math:binomialCoeff 4 4) 1) })
+    (test:eq (math:binomialCoeff 4 4) 1)
+    (test:eq (math:binomialCoeff 90 13) 1643385429346680) })
 
   (test:case "permutations" {
     (test:eq (math:permutations 5 3) 60)


### PR DESCRIPTION
Modifies `permutations` and `binomialCoeff` to do less division, reducing precision loss from floats when the answer can be faithfully represented as an integer.

Current: `(binomialCoeff 90 13) == 1643385429346678.5`
This patch: `(binomialCoeff 90 13) == 1643385429346680`

(dunno how ArkDoc authorship works when patching something)